### PR TITLE
Try to import MathDirective from its new location first

### DIFF
--- a/texext/mathcode.py
+++ b/texext/mathcode.py
@@ -83,9 +83,9 @@ from ast import parse, Expr, Expression
 from docutils.parsers.rst import directives
 
 try:
-    from sphinx.ext.mathbase import MathDirective
-except ImportError:  # Sphinx 1.8.0b1
     from sphinx.directives.patches import MathDirective
+except ImportError:  # Sphinx < 1.8.0b1
+    from sphinx.ext.mathbase import MathDirective
 
 
 def eval_code(code_str, context):


### PR DESCRIPTION
I've got sphinx 2.1.2.  I see this warning when running the tests:
```
texext/tests/test_tinypages.py::TestTopLevel::test_some_math
  /builddir/build/BUILD/texext-0.6.1/texext/mathcode.py:159: RemovedInSphinx30Warning: sphinx.ext.mathbase.MathDirective is moved to sphinx.directives.patches package.
    return super(MathCodeDirective, self).run()
```

Importing from the old location does not throw an ImportError; it merely warns.  Therefore, try the imports the other way around.  With older sphinx versions, the new location does not exist, therefore an ImportError is thrown and the old location is tried.