### PR TITLE
MNT: Import math node from docutils.nodes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from distutils.core import setup
 import versioneer
 
 extra_setup_kwargs = ({} if 'setuptools' not in sys.modules else
-                      dict(install_requires=['six', 'sphinx>=1.3.1']))
+                      dict(install_requires=['six', 'sphinx>=1.3.1', 'docutils>=0.8']))
 
 
 setup(name='texext',

--- a/texext/math_dollar.py
+++ b/texext/math_dollar.py
@@ -15,9 +15,9 @@ from functools import partial
 from docutils import nodes
 from docutils.utils import escape2null, unescape
 from docutils.transforms import Transform
+from docutils.nodes import math
 
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathbase import math
 
 
 def d2m_source(source):


### PR DESCRIPTION
When upgrading Sphinx to current master, this allows nibabel docs to build. It does not make the warning go away with the latest Sphinx, so it's possible that the warning is too easily triggered and we just put up with it.

Ref nipy/nibabel#894.