### PR TITLE
include requirements.txt and test-requirements.txt in pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,6 @@ include versioneer.py
 include texext/_version.py
 include README.rst
 include LICENSE
+include requirements.txt
+include text-requirements.txt
 recursive-include doc *


### PR DESCRIPTION
Addresses #6 by including `requirements.txt` and `test-requirements.txt` in `pip` package ([source](https://stackoverflow.com/a/38533721/2829487))