### PR TITLE
Adapt docstring test to Sphinx 7.2.x

### DIFF
--- a/texext/tests/test_docstrings.py
+++ b/texext/tests/test_docstrings.py
@@ -36,8 +36,8 @@ FRAGMENTS = dict(code=r'(code|tt|span)',
                  math=r'"math( notranslate)?( nohighlight)?"')
 DOCSTRING_RE = re.compile(
 r'<p>Here is the module docstring:</p>\n'
-r'<span class="target" id="module-texext.tests.for_docstrings"></span>'
-r'<p>A module to test docstring parsing with math such as '
+r'(<span class="target" id="module-texext.tests.for_docstrings"></span>)?'
+r'<p( id="module-texext.tests.for_docstrings")?>A module to test docstring parsing with math such as '
 r'<span class={math}'
 r'>\\\(\\gamma = \\cos\(\\alpha\)\\\)</span></p>\n'
 r'<p>Need to test other markup - so: '
@@ -57,7 +57,7 @@ r'<span class="sig-paren">\(</span><span class="sig-paren">\)</span>'
 r'<big>\(</big><big>\)</big>'  # sphinx 1.1.3
 ')'  # end of regexp group
 r'<a class="headerlink" href="#texext.tests.for_docstrings\.func" '
-r'title="Permalink to this definition">.+</a></dt>\n'
+r'title="(Permalink|Link) to this definition">.+</a></dt>\n'
 r'<dd><p>A docstring with math in first line '
 r'<span class={math}>\\\(z = \\beta\\\)</span></p>\n'
 r'<p>With some more <span class={math}>\\\(a = 1\\\)</span> math\. '


### PR DESCRIPTION
The Fedora Linux distribution is starting to work on upgrading Sphinx to 7.2.x.  The texext package fails the docstring test due to changed Sphinx output.  This PR is my attempt at fixing the issue.  There are two changes:
- The span with id `module-texext.tests.for_docstrings` has been removed.  Instead, the next `<p>` tag carries that id.
- "Permalink" has been changed to "Link"