### PR TITLE
Use packaging.version instead of distutils.version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,6 @@
 -r requirements.txt
 sympy>=1.0
 matplotlib>=3.1
+packaging
 pytest
 sphinxtesters>=0.2.3

--- a/texext/tests/plotdirective/conf.py
+++ b/texext/tests/plotdirective/conf.py
@@ -15,7 +15,7 @@
 import sys
 from os.path import join as pjoin, abspath
 import sphinx
-from packaging.version import parse
+import packaging.version as pkgv
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/texext/tests/plotdirective/conf.py
+++ b/texext/tests/plotdirective/conf.py
@@ -104,7 +104,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-if parse(sphinx.__version__) >= parse('1.3'):
+if pkgv.parse(sphinx.__version__) >= pkgv.parse('1.3'):
     html_theme = 'classic'
 else:
     html_theme = 'default'

--- a/texext/tests/plotdirective/conf.py
+++ b/texext/tests/plotdirective/conf.py
@@ -15,7 +15,7 @@
 import sys
 from os.path import join as pjoin, abspath
 import sphinx
-from distutils.version import LooseVersion
+from packaging.version import parse
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -104,7 +104,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
+if parse(sphinx.__version__) >= parse('1.3'):
     html_theme = 'classic'
 else:
     html_theme = 'default'


### PR DESCRIPTION
While running tests, several warnings of this form are issued:
```
texext/tests/test_custom_plotcontext.py::TestCustomPlotDirective::test_build_error
texext/tests/test_custom_plotcontext.py::TestCustomPlotDirective::test_build_error
  /tmp/tmpbhxf4hmw/source/conf.py:107: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
```

This PR makes the suggested change.