### PR TITLE
Use sphinx.ext.autodoc in tests

### DIFF
--- a/texext/tests/plotdirective/conf.py
+++ b/texext/tests/plotdirective/conf.py
@@ -32,6 +32,7 @@ sys.path.insert(0, abspath(pjoin('..', '..')))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'matplotlib.sphinxext.plot_directive',
     'texext.mathcode']

--- a/texext/tests/tinypages/conf.py
+++ b/texext/tests/tinypages/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 extensions = [
+    'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'texext.mathcode',
     'texext.math_dollar']


### PR DESCRIPTION
Removes the following warning while running tests:
```
=============================== warnings summary ===============================
texext/tests/test_plotdirective.py::TestTopPlotDirective::test_build_error
texext/tests/test_tinypages.py::TestTinyPages::test_build_error
texext/tests/test_tinypages.py::TestTopLevel::test_build_error
  /builddir/build/BUILD/python-texext-0.6.7-build/texext-0.6.7/texext/math_dollar.py:232: UserWarning: Need autodoc extension loaded for math_dollar to work on docstrings
    warn("Need autodoc extension loaded for math_dollar to work on "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 17 passed, 3 warnings in 1.65s ========================
```
