### PR TITLE
Make the tests pass with Docutils 0.22

### DIFF
--- a/texext/tests/test_plotdirective.py
+++ b/texext/tests/test_plotdirective.py
@@ -8,12 +8,14 @@ import re
 
 from six import PY3
 
+import docutils
 import sphinx
 
 SPHINX_ge_8p2 = sphinx.version_info[:2] >= (8, 2)
 SPHINX_ge_1p8 = sphinx.version_info[:2] >= (1, 8)
 SPHINX_ge_1p7 = sphinx.version_info[:2] >= (1, 7)
 SPHINX_ge_1p5 = sphinx.version_info[:2] >= (1, 5)
+DOCUTILS_ge_0p22 = docutils.__version_info__ >= (0, 22)
 
 from sphinxtesters import PageBuilder
 
@@ -28,10 +30,11 @@ def format_math_block(name, latex, label=None, number=None,
         number = 'True' if number is None else number
         label = 'True' if label is None else label
         id_part = '' if ids is None else 'ids="{}" '.format(ids)
-        nowrap = 'no-wrap="False" ' if SPHINX_ge_8p2 else ''
+        false = "0" if DOCUTILS_ge_0p22 else "False"
+        nowrap = f'no-wrap="{false}" ' if SPHINX_ge_8p2 else ''
         return (
             f'<math_block docname="{name}" {id_part}label="{label}" '
-            f'{nowrap}nowrap="False" number="{number}" '
+            f'{nowrap}nowrap="{false}" number="{number}" '
             f'xml:space="preserve">{latex}</math_block>'
         )
     number = 'None' if number is None else number
@@ -51,7 +54,7 @@ EXP_PLOT_AND_MATH = (
     '<title>Plot directive with mathcode</title>\n'
     '<paragraph>Some text</paragraph>\n'
     r'<literal_block '
-    '(force="False" )?'
+    f'(force="{0 if DOCUTILS_ge_0p22 else False}" )?'
     '(highlight_args="{}" )?'
     'language="python" '
     '(linenos="False" )?'

--- a/texext/tests/test_tinypages.py
+++ b/texext/tests/test_tinypages.py
@@ -2,9 +2,11 @@
 
 from os.path import (join as pjoin, dirname, isdir)
 
+import docutils
 import sphinx
 SPHINX_ge_1p5 = sphinx.version_info[:2] >= (1, 5)
 SPHINX_ge_1p8 = sphinx.version_info[:2] >= (1, 8)
+DOCUTILS_ge_0p22 = docutils.__version_info__ >= (0, 22)
 
 from sphinxtesters import PageBuilder
 
@@ -41,8 +43,9 @@ class TestTinyPages(PageBuilder):
             back_ref = (
                 '<paragraph>Refers to equation at '
                 '<pending_xref refdoc="some_math" refdomain="math" '
-                'refexplicit="False" reftarget="some-label" '
-                'reftype="eq" refwarn="True">'
+                f'refexplicit="{0 if DOCUTILS_ge_0p22 else False}" '
+                'reftarget="some-label" reftype="eq" '
+                f'refwarn="{1 if DOCUTILS_ge_0p22 else True}">'
                 '<literal classes="xref eq">some-label</literal>'
                 '</pending_xref>')
         else:


### PR DESCRIPTION
Docutils now normalizes boolean values using `str(int(value))`: <https://sourceforge.net/p/docutils/code/9691/>.

This change fixes test failures that can be seen here: <https://ci.debian.net/packages/t/texext/unstable/amd64/64790028/>.