### PR TITLE
Mark the texext extension as parallel-read safe.

### DIFF
--- a/texext/__init__.py
+++ b/texext/__init__.py
@@ -10,3 +10,5 @@ __version__ = _version.get_versions()['version']
 def setup(app):
     math_dollar.setup(app)
     mathcode.setup(app)
+    metadata = {"version": __version__, "parallel_read_safe": True}
+    return metadata


### PR DESCRIPTION
This enables parallel doc building in networkx (and others).

AFAICT the `texext` extension meets the criteria specified in the [sphinx docs](https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata) for being eligible for parallel reading.